### PR TITLE
Add unit tests for parseCmd

### DIFF
--- a/pairing-bot.go
+++ b/pairing-bot.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -366,90 +365,6 @@ func main() {
 
 	log.Printf("Listening on port %s", port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
-}
-
-func parseCmd(cmdStr string) (string, []string, error) {
-	var err error
-	var cmdList = []string{
-		"subscribe",
-		"unsubscribe",
-		"help",
-		"schedule",
-		"skip",
-		"unskip",
-		"status"}
-
-	var daysList = []string{
-		"monday",
-		"tuesday",
-		"wednesday",
-		"thursday",
-		"friday",
-		"saturday",
-		"sunday"}
-
-	// convert the string to a slice
-	// after this, we have a value "cmd" of type []string
-	// where cmd[0] is the command and cmd[1:] are any arguments
-	space := regexp.MustCompile(`\s+`)
-	cmdStr = space.ReplaceAllString(cmdStr, ` `)
-	cmdStr = strings.TrimSpace(cmdStr)
-	cmdStr = strings.ToLower(cmdStr)
-	cmd := strings.Split(cmdStr, ` `)
-
-	// Big validation logic -- hellooo darkness my old frieeend
-	switch {
-	// if there's nothing in the command string srray
-	case len(cmd) == 0:
-		err = errors.New("the user-issued command was blank")
-		return "help", nil, err
-
-	// if there's a valid command and if there's no arguments
-	case contains(cmdList, cmd[0]) && len(cmd) == 1:
-		if cmd[0] == "schedule" || cmd[0] == "skip" || cmd[0] == "unskip" {
-			err = errors.New("the user issued a command without args, but it required args")
-			return "help", nil, err
-		}
-		return cmd[0], nil, err
-
-	// if there's a valid command and there's some arguments
-	case contains(cmdList, cmd[0]) && len(cmd) > 1:
-		switch {
-		case cmd[0] == "subscribe" || cmd[0] == "unsubscribe" || cmd[0] == "help" || cmd[0] == "status":
-			err = errors.New("the user issued a command with args, but it disallowed args")
-			return "help", nil, err
-		case cmd[0] == "skip" && (len(cmd) != 2 || cmd[1] != "tomorrow"):
-			err = errors.New("the user issued SKIP with malformed arguments")
-			return "help", nil, err
-		case cmd[0] == "unskip" && (len(cmd) != 2 || cmd[1] != "tomorrow"):
-			err = errors.New("the user issued UNSKIP with malformed arguments")
-			return "help", nil, err
-		case cmd[0] == "schedule":
-			for _, v := range cmd[1:] {
-				if contains(daysList, v) == false {
-					err = errors.New("the user issued SCHEDULE with malformed arguments")
-					return "help", nil, err
-				}
-			}
-			fallthrough
-		default:
-			return cmd[0], cmd[1:], err
-		}
-
-	// if there's not a valid command
-	default:
-		err = errors.New("the user-issued command wasn't valid")
-		return "help", nil, err
-	}
-}
-
-func contains(list []string, cmd string) bool {
-	for _, v := range list {
-		if v == cmd {
-			return true
-		}
-	}
-	return false
 }
 
 func nope(w http.ResponseWriter, r *http.Request) {

--- a/parseCmd.go
+++ b/parseCmd.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type parsingErr struct{ msg string }
+
+func (e parsingErr) Error() string {
+	return fmt.Sprintf("Error when parsing command: %s", e.msg)
+}
+
+func parseCmd(cmdStr string) (string, []string, error) {
+	var err error
+	var cmdList = []string{
+		"subscribe",
+		"unsubscribe",
+		"help",
+		"schedule",
+		"skip",
+		"unskip",
+		"status"}
+
+	var daysList = []string{
+		"monday",
+		"tuesday",
+		"wednesday",
+		"thursday",
+		"friday",
+		"saturday",
+		"sunday"}
+
+	// convert the string to a slice
+	// after this, we have a value "cmd" of type []string
+	// where cmd[0] is the command and cmd[1:] are any arguments
+	space := regexp.MustCompile(`\s+`)
+	cmdStr = space.ReplaceAllString(cmdStr, ` `)
+	cmdStr = strings.TrimSpace(cmdStr)
+	cmdStr = strings.ToLower(cmdStr)
+	cmd := strings.Split(cmdStr, ` `)
+
+	// Big validation logic -- hellooo darkness my old frieeend
+	switch {
+	// if there's nothing in the command string srray
+	case len(cmd) == 0:
+		err = errors.New("the user-issued command was blank")
+		return "help", nil, err
+
+	// if there's a valid command and if there's no arguments
+	case contains(cmdList, cmd[0]) && len(cmd) == 1:
+		if cmd[0] == "schedule" || cmd[0] == "skip" || cmd[0] == "unskip" {
+			err = &parsingErr{"the user issued a command without args, but it reqired args"}
+			return "help", nil, err
+		}
+		return cmd[0], nil, err
+
+	// if there's a valid command and there's some arguments
+	case contains(cmdList, cmd[0]) && len(cmd) > 1:
+		switch {
+		case cmd[0] == "subscribe" || cmd[0] == "unsubscribe" || cmd[0] == "help" || cmd[0] == "status":
+			err = &parsingErr{"the user issued a command with args, but it disallowed args"}
+			return "help", nil, err
+		case cmd[0] == "skip" && (len(cmd) != 2 || cmd[1] != "tomorrow"):
+			err = &parsingErr{"the user issued SKIP with malformed arguments"}
+			return "help", nil, err
+		case cmd[0] == "unskip" && (len(cmd) != 2 || cmd[1] != "tomorrow"):
+			err = &parsingErr{"the user issued UNSKIP with malformed arguments"}
+			return "help", nil, err
+		case cmd[0] == "schedule":
+			for _, v := range cmd[1:] {
+				if !contains(daysList, v) {
+					err = &parsingErr{"the user issued SCHEDULE with malformed arguments"}
+					return "help", nil, err
+				}
+			}
+			fallthrough
+		default:
+			return cmd[0], cmd[1:], err
+		}
+
+	// if there's not a valid command
+	default:
+		err = &parsingErr{"the user-issued command wasn't valid"}
+		return "help", nil, err
+	}
+}
+
+func contains(list []string, cmd string) bool {
+	for _, v := range list {
+		if v == cmd {
+			return true
+		}
+	}
+	return false
+}

--- a/parseCmd_test.go
+++ b/parseCmd_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"testing"
+)
+
+var daysList = map[string]struct{}{
+	"monday":    {},
+	"tuesday":   {},
+	"wednesday": {},
+	"thursday":  {},
+	"friday":    {},
+	"saturday":  {},
+	"sunday":    {},
+}
+
+// due to the difficulties around comparing error return values (and because we don't want to compare error messages),
+// the struct contains expectErr to indicate whether an error is expected, instead of an actual error value
+var tableNoArgs = []struct {
+	testName   string
+	inputStr   string
+	wantedCmd  string
+	wantedArgs []string
+	expectErr  bool
+}{
+	{"subscribe_correct_usage", "subscribe", "subscribe", nil, false},
+	{"subscribe_wrong_usage", "subscribe mon", "help", nil, true},
+	{"unsubscribe_correct_usage", "unsubscribe", "unsubscribe", nil, false},
+	{"unsubscribe_wrong_usage", "unsubscribe tuesday", "help", nil, true},
+	{"help_correct_usage", "help", "help", nil, false},
+	{"help_wrong_usage", "help me", "help", nil, true},
+	{"status_correct_usage", "status", "status", nil, false},
+	{"status_wrong_usage", "status me", "help", nil, true},
+}
+
+func TestParseCmdNoArgs(t *testing.T) {
+	for _, tt := range tableNoArgs {
+		t.Run(tt.testName, func(t *testing.T) {
+			gotCmd, gotArgs, gotErr := parseCmd(tt.inputStr)
+			if gotCmd != tt.wantedCmd {
+				t.Errorf("got %v, %v\n", gotCmd, gotArgs)
+			}
+
+			_, ok := gotErr.(*parsingErr)
+
+			if tt.expectErr && !ok {
+				t.Errorf("Expected parsingErr but didn't get one\n")
+			} else if !tt.expectErr && ok {
+				t.Errorf("Got unexpected parsingError\n")
+			}
+		})
+	}
+}
+
+var tableWithArgs = []struct {
+	testName   string
+	inputStr   string
+	wantedCmd  string
+	wantedArgs []string
+	expectErr  bool
+}{
+	{"schedule_1_arg", "schedule monday", "schedule", []string{"monday"}, false},
+	{"schedule_2_args", "schedule monday friday", "schedule", []string{"monday", "friday"}, false},
+	{"schedule_3_args", "schedule monday wednesday friday", "schedule", []string{"monday", "wednesday", "friday"}, false},
+	{"schedule_4_args", "schedule monday wednesday friday sunday", "schedule", []string{"monday", "wednesday", "friday", "sunday"}, false},
+	{"schedule_weekend_only", "schedule sunday", "schedule", []string{"sunday"}, false},
+	{"schedule_wrong_usage", "schedule", "help", nil, true},
+	{"skip_correct_usage", "skip tomorrow", "skip", []string{"tomorrow"}, false},
+	{"skip_wrong_usage", "skip monday", "help", nil, true},
+	{"skip_wrong_usage", "skip whenever", "help", nil, true},
+	{"skip_wrong_usage", "skip", "help", nil, true},
+	{"unskip_correct_usage", "unskip tomorrow", "unskip", []string{"tomorrow"}, false},
+	{"unskip_wrong_usage", "unskip today", "help", nil, true},
+	{"unskip_wrong_usage", "unskip friday", "help", nil, true},
+	{"unskip_wrong_usage", "unskip", "help", nil, true},
+}
+
+func TestParseCmdWithArgs(t *testing.T) {
+	for _, tt := range tableWithArgs {
+		t.Run(tt.testName, func(t *testing.T) {
+			gotCmd, gotArgs, gotErr := parseCmd(tt.inputStr)
+			if gotCmd != tt.wantedCmd || len(gotArgs) != len(tt.wantedArgs) {
+				t.Errorf("got %v, %v, wanted %v, %v\n", gotCmd, gotArgs, tt.wantedCmd, tt.wantedArgs)
+			}
+
+			switch gotCmd {
+			case "schedule":
+				for i, arg := range gotArgs {
+					if _, ok := daysList[arg]; !ok {
+						t.Errorf("Wrong argument %v for command %v\n", gotArgs[i], gotCmd)
+					}
+				}
+			case "skip":
+				if gotArgs[0] != "tomorrow" {
+					t.Errorf("Wrong argument %v for command %v\n", gotArgs[0], gotCmd)
+				}
+			case "unskip":
+				if gotArgs[0] != "tomorrow" {
+					t.Errorf("Wrong argument %v for command %v\n", gotArgs[0], gotCmd)
+				}
+			default:
+				if gotCmd != "help" {
+					t.Errorf("unknown command %v\n", gotCmd)
+				}
+			}
+
+			_, ok := gotErr.(*parsingErr)
+
+			if tt.expectErr && !ok {
+				t.Errorf("Expected parsingErr but didn't get one\n")
+			} else if !tt.expectErr && ok {
+				t.Errorf("Got unexpected parsingError\n")
+			}
+		})
+	}
+}
+
+var tableMisc = []struct {
+	testName   string
+	inputStr   string
+	wantedCmd  string
+	wantedArgs []string
+	expectErr  bool
+}{
+	{"command_is_superstring", "scheduleing monday", "help", nil, true},
+	{"command_is_substring", "schedul monday", "help", nil, true},
+	{"command_is_undefined", "mooh", "help", nil, true},
+	{"command_is_capitalized", "Help", "help", nil, false},
+}
+
+func TestParseCmdMisc(t *testing.T) {
+	for _, tt := range tableMisc {
+		t.Run(tt.testName, func(t *testing.T) {
+			gotCmd, gotArgs, gotErr := parseCmd(tt.inputStr)
+			if gotCmd != tt.wantedCmd {
+				t.Errorf("got %v, %v, wanted %v, %v\n", gotCmd, gotArgs, tt.wantedCmd, tt.wantedArgs)
+			}
+			_, ok := gotErr.(*parsingErr)
+
+			if tt.expectErr && !ok {
+				t.Errorf("Expected parsingErr but didn't get one\n")
+			} else if !tt.expectErr && ok {
+				t.Errorf("Got unexpected parsingError\n")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds unit tests for the `parseCmd` function.
The function was split out into a different file for easier navigation.
A custom errror type `parsingErr` was introduced, which maybe isn't strictly necessary but it might be helpful to have more differenciated errors as the project grows.
PR for running unit tests in GCP is upcoming.