### PR TITLE
Run go test in cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,6 +6,13 @@ steps:
   - name: 'go'
     path: '/gopath'
 
+- name: 'gcr.io/cloud-builders/go'
+  args: ['test']
+  env: [GOPATH=/gopath']
+  volumes:
+  - name: 'go'
+    path: '/gopath'
+
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ['app','deploy', 'cron.yaml']
   timeout: 600s


### PR DESCRIPTION
Run `go test` in cloudbuild so that tests (see https://github.com/thwidge/pairing-bot/pull/14) get run before deploy.
This looks too easy though..?