### PR TITLE
Refactor with interfaces for DB and Zulip interaction

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,7 +44,7 @@ type botNoResponse struct {
 }
 
 type userRequest interface {
-	validateJSON(ctx context.Context, r *http.Request) error
+	validateJSON(r *http.Request) error
 	validateAuthCreds(ctx context.Context, tokenFromDB string) bool
 	validateInteractionType(ctx context.Context) *botResponse
 	ignoreInteractionType(ctx context.Context) *botNoResponse
@@ -96,7 +96,7 @@ func (zun *zulipUserNotification) sendUserMessage(ctx context.Context, botPasswo
 	return nil
 }
 
-func (zur *zulipUserRequest) validateJSON(ctx context.Context, r *http.Request) error {
+func (zur *zulipUserRequest) validateJSON(r *http.Request) error {
 	var userReq incomingJSON
 	// Look at the incoming webhook and slurp up the JSON
 	// Error if the JSON from Zulip itself is bad
@@ -160,7 +160,7 @@ func (mun *mockUserNotification) sendUserMessage(ctx context.Context, botPasswor
 	return nil
 }
 
-func (mur *mockUserRequest) validateJSON(ctx context.Context, r *http.Request) error {
+func (mur *mockUserRequest) validateJSON(r *http.Request) error {
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"net/http"
+)
+
+// This is a struct that gets only what
+// we need from the incoming JSON payload
+type incomingJSON struct {
+	Data    string `json:"data"`
+	Token   string `json:"token"`
+	Trigger string `json:"trigger"`
+	Message struct {
+		SenderID         int         `json:"sender_id"`
+		DisplayRecipient interface{} `json:"display_recipient"`
+		SenderEmail      string      `json:"sender_email"`
+		SenderFullName   string      `json:"sender_full_name"`
+	} `json:"message"`
+}
+
+type UserDataFromJSON struct {
+	userID    string
+	userEmail string
+	userName  string
+}
+
+// Zulip has to get JSON back from the bot,
+// this does that. An empty message field stops
+// zulip from throwing an error at the user that
+// messaged the bot, but doesn't send a response
+type botResponse struct {
+	Message string `json:"content"`
+}
+
+type botNoResponse struct {
+	Message bool `json:"response_not_required"`
+}
+
+type userRequest interface {
+	validateJSON(ctx context.Context, r *http.Request) error
+	validateAuthCreds(ctx context.Context, tokenFromDB string) bool
+	validateInteractionType(ctx context.Context) *botResponse
+	ignoreInteractionType(ctx context.Context) *botNoResponse
+	sanitizeUserInput(ctx context.Context) (string, []string, error)
+	extractUserData(ctx context.Context) *UserDataFromJSON // does this need an error return value? anything that hasn't been validated previously?
+}
+
+type userNotification interface {
+	sendUserMessage(ctx context.Context, botPassword, user, message string) error
+}
+
+// implements userRequest
+type zulipUserRequest struct {
+	json incomingJSON
+}
+
+// implements userNotification
+type zulipUserNotification struct {
+	botUsername string
+	zulipAPIURL string
+}
+
+func (zun *zulipUserNotification) sendUserMessage(ctx context.Context, botPassword, user, message string) error {
+	return nil
+}
+
+func (zur *zulipUserRequest) validateJSON(ctx context.Context, r *http.Request) error {
+	return nil
+}
+
+func (zur *zulipUserRequest) validateAuthCreds(ctx context.Context, tokenFromDB string) bool {
+	return false
+}
+
+// if the zulip msg is posted in a stream, don't treat it as a command
+func (zur *zulipUserRequest) validateInteractionType(ctx context.Context) *botResponse {
+	return nil
+}
+
+// if there aren't two 'recipients' (one sender and one receiver),
+// then don't respond. this stops pairing bot from responding in the group
+// chat she starts when she matches people
+func (zur *zulipUserRequest) ignoreInteractionType(ctx context.Context) *botNoResponse {
+	return nil
+}
+
+func (zur *zulipUserRequest) sanitizeUserInput(ctx context.Context) (string, []string, error) {
+	return "", nil, nil
+}
+
+func (zur *zulipUserRequest) extractUserData(ctx context.Context) *UserDataFromJSON {
+	return &UserDataFromJSON{}
+}
+
+// Mock types
+
+// implements userRequest
+type mockUserRequest struct {
+}
+
+// implements userNotification
+type mockUserNotification struct {
+}
+
+func (mun *mockUserNotification) sendUserMessage(ctx context.Context, botPassword, user, message string) error {
+	return nil
+}
+
+func (mur *mockUserRequest) validateJSON(ctx context.Context, r *http.Request) error {
+	return nil
+}
+
+func (mur *mockUserRequest) validateAuthCreds(ctx context.Context, tokenFromDB string) bool {
+	return false
+}
+
+func (mur *mockUserRequest) validateInteractionType(ctx context.Context) *botResponse {
+	return nil
+}
+
+func (mur *mockUserRequest) ignoreInteractionType(ctx context.Context) *botNoResponse {
+	return nil
+}
+
+func (mur *mockUserRequest) sanitizeUserInput(ctx context.Context) (string, []string, error) {
+	return "", nil, nil
+}
+
+func (mur *mockUserRequest) extractUserData(ctx context.Context) *UserDataFromJSON {
+	return &UserDataFromJSON{}
+}

--- a/database.go
+++ b/database.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+)
+
+// this is what we send to / receive from Firestore
+// var recurser = map[string]interface{}{
+// 	"id":                 "string",
+// 	"name":               "string",
+// 	"email":              "string",
+// 	"isSkippingTomorrow": false,
+// 	"schedule": map[string]interface{}{
+// 		"monday":    false,
+// 		"tuesday":   false,
+// 		"wednesday": false,
+// 		"thursday":  false,
+// 		"friday":    false,
+// 		"saturday":  false,
+// 		"sunday":    false,
+// 	},
+// }
+
+type Recurser struct {
+	id                 string
+	name               string
+	email              string
+	isSkippingTomorrow bool
+	schedule           map[string]interface{}
+	isSubscribed       bool
+}
+
+func (r *Recurser) ConvertToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"id":                 r.id,
+		"name":               r.name,
+		"email":              r.email,
+		"isSkippingTomorrow": r.isSkippingTomorrow,
+		"schedule":           r.schedule,
+	}
+}
+
+func MapToStruct(m map[string]interface{}) Recurser {
+	// isSubscribed is missing here because it's not in the map
+	return Recurser{id: m["id"].(string),
+		name:               m["name"].(string),
+		email:              m["email"].(string),
+		isSkippingTomorrow: m["isSkippingTomorrow"].(bool),
+		schedule:           m["schedule"].(map[string]interface{}),
+	}
+}
+
+// DB Lookups of Pairing Bot subscribers (= "Recursers")
+
+type RecurserDB interface {
+	GetByUserID(ctx context.Context, userID, userEmail, userName string) (Recurser, error)
+	GetAllUsers(ctx context.Context) ([]Recurser, error)
+	Set(ctx context.Context, userID string, recurser Recurser) error
+	Delete(ctx context.Context, userID string) error
+	ListPairingTomorrow(ctx context.Context) ([]Recurser, error)
+	ListSkippingTomorrow(ctx context.Context) ([]Recurser, error)
+	UnsetSkippingTomorrow(ctx context.Context, recurser Recurser) error
+}
+
+// implements RecurserDB
+type FirestoreRecurserDB struct {
+	client *firestore.Client
+}
+
+func (f *FirestoreRecurserDB) GetByUserID(ctx context.Context, userID, userEmail, userName string) (Recurser, error) {
+	return Recurser{}, nil
+}
+
+func (f *FirestoreRecurserDB) GetAllUsers(ctx context.Context) ([]Recurser, error) {
+	return nil, nil
+}
+
+func (f *FirestoreRecurserDB) Set(ctx context.Context, userID string, recurser Recurser) error {
+	return nil
+}
+
+func (f *FirestoreRecurserDB) Delete(ctx context.Context, userID string) error {
+	return nil
+}
+
+func (f *FirestoreRecurserDB) ListPairingTomorrow(ctx context.Context) ([]Recurser, error) {
+	return nil, nil
+}
+
+func (f *FirestoreRecurserDB) ListSkippingTomorrow(ctx context.Context) ([]Recurser, error) {
+	return nil, nil
+}
+
+func (f *FirestoreRecurserDB) UnsetSkippingTomorrow(ctx context.Context, recurser Recurser) error {
+	return nil
+}
+
+// implements RecurserDB
+type MockRecurserDB struct{}
+
+func (m *MockRecurserDB) GetByUserID(ctx context.Context, userID, userEmail, userName string) (Recurser, error) {
+	return Recurser{}, nil
+}
+
+func (m *MockRecurserDB) GetAllUsers(ctx context.Context) ([]Recurser, error) {
+	return nil, nil
+}
+
+func (m *MockRecurserDB) Set(ctx context.Context, userID string, recurser Recurser) error {
+	return nil
+}
+
+func (m *MockRecurserDB) Delete(ctx context.Context, userID string) error {
+	return nil
+}
+
+func (m *MockRecurserDB) ListPairingTomorrow(ctx context.Context) ([]Recurser, error) {
+	return nil, nil
+}
+
+func (m *MockRecurserDB) ListSkippingTomorrow(ctx context.Context) ([]Recurser, error) {
+	return nil, nil
+}
+
+func (m *MockRecurserDB) UnsetSkippingTomorrow(ctx context.Context, userID string) error {
+	return nil
+}
+
+// DB Lookups of tokens
+
+type APIAuthDB interface {
+	GetKey(ctx context.Context, col, doc string) (string, error)
+}
+
+// implements APIAuthDB
+type FirestoreAPIAuthDB struct {
+	client *firestore.Client
+}
+
+func (f *FirestoreAPIAuthDB) GetKey(ctx context.Context, col, doc string) (string, error) {
+	return "", nil
+}
+
+// implements APIAuthDB
+type MockAPIAuthDB struct{}
+
+func (f *MockAPIAuthDB) GetKey(ctx context.Context, col, doc string) (string, error) {
+	return "", nil
+}

--- a/database.go
+++ b/database.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	"context"
+	"log"
+	"strings"
+	"time"
 
 	"cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // this is what we send to / receive from Firestore
@@ -70,30 +76,132 @@ type FirestoreRecurserDB struct {
 }
 
 func (f *FirestoreRecurserDB) GetByUserID(ctx context.Context, userID, userEmail, userName string) (Recurser, error) {
-	return Recurser{}, nil
+	// get the users "document" (database entry) out of firestore
+	// we temporarily keep it in 'doc'
+	doc, err := f.client.Collection("recursers").Doc(userID).Get(ctx)
+	// this says "if there's an error, and if that error was not document-not-found"
+	if err != nil && status.Code(err) != codes.NotFound {
+		return Recurser{}, err
+	}
+
+	// if there's a db entry, that means they were already subscribed to pairing bot
+	// if there's not, they were not subscribed
+	isSubscribed := doc.Exists()
+
+	// if the user is in the database, get their current state into this map
+	// also assign their zulip name to the name field, just in case it changed
+	// also assign their email, for the same reason
+	var recurser map[string]interface{}
+
+	if isSubscribed {
+		recurser = doc.Data()
+		recurser["name"] = userName
+		recurser["email"] = userEmail
+	}
+
+	// now put the data from the recurser map into a Recurser struct
+	r := MapToStruct(recurser)
+	r.isSubscribed = isSubscribed
+	return r, nil
 }
 
 func (f *FirestoreRecurserDB) GetAllUsers(ctx context.Context) ([]Recurser, error) {
-	return nil, nil
+
+	var recursersList []Recurser
+	var r Recurser
+
+	iter := f.client.Collection("recursers").Documents(ctx)
+	for {
+		doc, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		r = MapToStruct(doc.Data())
+
+		recursersList = append(recursersList, r)
+	}
+	return recursersList, nil
 }
 
 func (f *FirestoreRecurserDB) Set(ctx context.Context, userID string, recurser Recurser) error {
-	return nil
+
+	r := recurser.ConvertToMap()
+	_, err := f.client.Collection("recursers").Doc(userID).Set(ctx, r, firestore.MergeAll)
+	return err
+
 }
 
 func (f *FirestoreRecurserDB) Delete(ctx context.Context, userID string) error {
-	return nil
+	_, err := f.client.Collection("recursers").Doc(userID).Delete(ctx)
+	return err
 }
 
 func (f *FirestoreRecurserDB) ListPairingTomorrow(ctx context.Context) ([]Recurser, error) {
-	return nil, nil
+	// this gets the time from system time, which is UTC
+	// on app engine (and most other places). This works
+	// fine for us in NYC, but might not if pairing bot
+	// were ever running in another time zone
+	today := strings.ToLower(time.Now().Weekday().String())
+
+	var recursersList []Recurser
+	var r Recurser
+
+	// ok this is how we have to get all the recursers. it's weird.
+	// this query returns an iterator, and then we have to use firestore
+	// magic to iterate across the results of the query and store them
+	// into our 'recursersList' variable which is a slice of map[string]interface{}
+	iter := f.client.Collection("recursers").Where("isSkippingTomorrow", "==", false).Where("schedule."+today, "==", true).Documents(ctx)
+	for {
+		doc, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		r = MapToStruct(doc.Data())
+
+		recursersList = append(recursersList, r)
+	}
+
+	return recursersList, nil
 }
 
 func (f *FirestoreRecurserDB) ListSkippingTomorrow(ctx context.Context) ([]Recurser, error) {
-	return nil, nil
+
+	var skippersList []Recurser
+	var r Recurser
+
+	iter := f.client.Collection("recursers").Where("isSkippingTomorrow", "==", true).Documents(ctx)
+	for {
+		doc, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		r = MapToStruct(doc.Data())
+
+		skippersList = append(skippersList, r)
+	}
+	return skippersList, nil
 }
 
 func (f *FirestoreRecurserDB) UnsetSkippingTomorrow(ctx context.Context, recurser Recurser) error {
+
+	r := recurser.ConvertToMap()
+	r["isSkippingTomorrow"] = false
+
+	_, err := f.client.Collection("recursers").Doc(r["id"].(string)).Set(ctx, r, firestore.MergeAll)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -140,7 +248,14 @@ type FirestoreAPIAuthDB struct {
 }
 
 func (f *FirestoreAPIAuthDB) GetKey(ctx context.Context, col, doc string) (string, error) {
-	return "", nil
+	res, err := f.client.Collection(col).Doc(doc).Get(ctx)
+	if err != nil {
+		log.Println("Something weird happened trying to read the auth token from the database")
+		return "", err
+	}
+
+	token := res.Data()
+	return token["value"].(string), nil
 }
 
 // implements APIAuthDB

--- a/dispatch.go
+++ b/dispatch.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const helpMessage string = "**How to use Pairing Bot:**\n* `subscribe` to start getting matched with other Pairing Bot users for pair programming\n* `schedule monday wednesday friday` to set your weekly pairing schedule\n  * In this example, I've been set to find pairing partners for you on every Monday, Wednesday, and Friday\n  * You can schedule pairing for any combination of days in the week\n* `skip tomorrow` to skip pairing tomorrow\n  * This is valid until matches go out at 04:00 UTC\n* `unskip tomorrow` to undo skipping tomorrow\n* `status` to show your current schedule, skip status, and name\n* `unsubscribe` to stop getting matched entirely\n\nIf you've found a bug, please [submit an issue on github](https://github.com/thwidge/pairing-bot/issues)!"
+const subscribeMessage string = "Yay! You're now subscribed to Pairing Bot!\nCurrently, I'm set to find pair programming partners for you on **Mondays**, **Tuesdays**, **Wednesdays**, **Thursdays**, and **Fridays**.\nYou can customize your schedule any time with `schedule` :)"
+const unsubscribeMessage string = "You're unsubscribed!\nI won't find pairing partners for you unless you `subscribe`.\n\nBe well :)"
+const notSubscribedMessage string = "You're not subscribed to Pairing Bot <3"
+
+var writeErrorMessage = fmt.Sprintf("Something went sideways while writing to the database. You should probably ping %v", owner)
+var readErrorMessage = fmt.Sprintf("Something went sideways while reading from the database. You should probably ping %v", owner)
+
+func dispatch(ctx context.Context, client *firestore.Client, cmd string, cmdArgs []string, userID string, userEmail string, userName string) (string, error) {
+	var response string
+	var err error
+	var recurser = map[string]interface{}{
+		"id":                 "string",
+		"name":               "string",
+		"email":              "string",
+		"isSkippingTomorrow": false,
+		"schedule": map[string]interface{}{
+			"monday":    false,
+			"tuesday":   false,
+			"wednesday": false,
+			"thursday":  false,
+			"friday":    false,
+			"saturday":  false,
+			"sunday":    false,
+		},
+	}
+
+	// get the users "document" (database entry) out of firestore
+	// we temporarily keep it in 'doc'
+	doc, err := client.Collection("recursers").Doc(userID).Get(ctx)
+	// this says "if there's an error, and if that error was not document-not-found"
+	if err != nil && status.Code(err) != codes.NotFound {
+		response = readErrorMessage
+		return response, err
+	}
+	// if there's a db entry, that means they were already subscribed to pairing bot
+	// if there's not, they were not subscribed
+	isSubscribed := doc.Exists()
+
+	// if the user is in the database, get their current state into this map
+	// also assign their zulip name to the name field, just in case it changed
+	// also assign their email, for the same reason
+	if isSubscribed {
+		recurser = doc.Data()
+		recurser["name"] = userName
+		recurser["email"] = userEmail
+	}
+	// here's the actual actions. command input from
+	// the user has already been sanitized, so we can
+	// trust that cmd and cmdArgs only have valid stuff in them
+	switch cmd {
+	case "schedule":
+		if !isSubscribed {
+			response = notSubscribedMessage
+			break
+		}
+		// create a new blank schedule
+		var newSchedule = map[string]interface{}{
+			"monday":    false,
+			"tuesday":   false,
+			"wednesday": false,
+			"thursday":  false,
+			"friday":    false,
+			"saturday":  false,
+			"sunday":    false,
+		}
+		// populate it with the new days they want to pair on
+		for _, day := range cmdArgs {
+			newSchedule[day] = true
+		}
+		// put it in the database
+		recurser["schedule"] = newSchedule
+		_, err = client.Collection("recursers").Doc(userID).Set(ctx, recurser, firestore.MergeAll)
+		if err != nil {
+			response = writeErrorMessage
+			break
+		}
+		response = "Awesome, your new schedule's been set! You can check it with `status`."
+
+	case "subscribe":
+		if isSubscribed {
+			response = "You're already subscribed! Use `schedule` to set your schedule."
+			break
+		}
+
+		// recurser isn't really a type, because we're using maps
+		// and not struct. but we're using it *as* a type,
+		// and this is the closest thing to a definition that occurs
+		recurser = map[string]interface{}{
+			"id":                 userID,
+			"name":               userName,
+			"email":              userEmail,
+			"isSkippingTomorrow": false,
+			"schedule": map[string]interface{}{
+				"monday":    true,
+				"tuesday":   true,
+				"wednesday": true,
+				"thursday":  true,
+				"friday":    true,
+				"saturday":  false,
+				"sunday":    false,
+			},
+		}
+		_, err = client.Collection("recursers").Doc(userID).Set(ctx, recurser)
+		if err != nil {
+			response = writeErrorMessage
+			break
+		}
+		response = subscribeMessage
+
+	case "unsubscribe":
+		if !isSubscribed {
+			response = notSubscribedMessage
+			break
+		}
+		_, err = client.Collection("recursers").Doc(userID).Delete(ctx)
+		if err != nil {
+			response = writeErrorMessage
+			break
+		}
+		response = unsubscribeMessage
+
+	case "skip":
+		if !isSubscribed {
+			response = notSubscribedMessage
+			break
+		}
+		recurser["isSkippingTomorrow"] = true
+		_, err = client.Collection("recursers").Doc(userID).Set(ctx, recurser, firestore.MergeAll)
+		if err != nil {
+			response = writeErrorMessage
+			break
+		}
+		response = `Tomorrow: cancelled. I feel you. **I will not match you** for pairing tomorrow <3`
+
+	case "unskip":
+		if !isSubscribed {
+			response = notSubscribedMessage
+			break
+		}
+		recurser["isSkippingTomorrow"] = false
+		_, err = client.Collection("recursers").Doc(userID).Set(ctx, recurser, firestore.MergeAll)
+		if err != nil {
+			response = writeErrorMessage
+			break
+		}
+		response = "Tomorrow: uncancelled! Heckin *yes*! **I will match you** for pairing tomorrow :)"
+
+	case "status":
+		if !isSubscribed {
+			response = notSubscribedMessage
+			break
+		}
+		// this particular days list is for sorting and printing the
+		// schedule correctly, since it's stored in a map in all lowercase
+		var daysList = []string{
+			"Monday",
+			"Tuesday",
+			"Wednesday",
+			"Thursday",
+			"Friday",
+			"Saturday",
+			"Sunday"}
+
+		// get their current name
+		whoami := recurser["name"]
+
+		// get skip status and prepare to write a sentence with it
+		var skipStr string
+		if recurser["isSkippingTomorrow"].(bool) {
+			skipStr = " "
+		} else {
+			skipStr = " not "
+		}
+
+		// make a sorted list of their schedule
+		var schedule []string
+		for _, day := range daysList {
+			// this line is a little wild, sorry. it looks so weird because we
+			// have to do type assertion on both interface types
+			if recurser["schedule"].(map[string]interface{})[strings.ToLower(day)].(bool) {
+				schedule = append(schedule, day)
+			}
+		}
+		// make a lil nice-lookin schedule string
+		var scheduleStr string
+		for i := range schedule[:len(schedule)-1] {
+			scheduleStr += schedule[i] + "s, "
+		}
+		if len(schedule) > 1 {
+			scheduleStr += "and " + schedule[len(schedule)-1] + "s"
+		} else if len(schedule) == 1 {
+			scheduleStr += schedule[0] + "s"
+		}
+
+		response = fmt.Sprintf("* You're %v\n* You're scheduled for pairing on **%v**\n* **You're%vset to skip** pairing tomorrow", whoami, scheduleStr, skipStr)
+
+	case "help":
+		response = helpMessage
+	default:
+		// this won't execute because all input has been sanitized
+		// by parseCmd() and all cases are handled explicitly above
+	}
+	return response, err
+}

--- a/dispatch.go
+++ b/dispatch.go
@@ -14,11 +14,9 @@ const notSubscribedMessage string = "You're not subscribed to Pairing Bot <3"
 var writeErrorMessage = fmt.Sprintf("Something went sideways while writing to the database. You should probably ping %v", owner)
 var readErrorMessage = fmt.Sprintf("Something went sideways while reading from the database. You should probably ping %v", owner)
 
-func dispatch(pl *PairingLogic, cmd string, cmdArgs []string, userID string, userEmail string, userName string) (string, error) {
+func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []string, userID string, userEmail string, userName string) (string, error) {
 	var response string
 	var err error
-
-	ctx := context.Background()
 
 	rec, err := pl.rdb.GetByUserID(ctx, userID, userEmail, userName)
 	if err != nil {
@@ -54,8 +52,6 @@ func dispatch(pl *PairingLogic, cmd string, cmdArgs []string, userID string, use
 		// put it in the database
 		rec.schedule = newSchedule
 
-		ctx := context.Background()
-
 		err = pl.rdb.Set(ctx, userID, rec)
 
 		if err != nil {
@@ -87,7 +83,6 @@ func dispatch(pl *PairingLogic, cmd string, cmdArgs []string, userID string, use
 			schedule:           defaultSchedule,
 		}
 
-		ctx := context.Background()
 		err = pl.rdb.Set(ctx, userID, newRecurser)
 
 		if err != nil {
@@ -101,8 +96,6 @@ func dispatch(pl *PairingLogic, cmd string, cmdArgs []string, userID string, use
 			response = notSubscribedMessage
 			break
 		}
-
-		ctx := context.Background()
 
 		err := pl.rdb.Delete(ctx, userID)
 
@@ -120,8 +113,6 @@ func dispatch(pl *PairingLogic, cmd string, cmdArgs []string, userID string, use
 
 		rec.isSkippingTomorrow = true
 
-		ctx := context.Background()
-
 		err := pl.rdb.Set(ctx, userID, rec)
 		if err != nil {
 			response = writeErrorMessage
@@ -135,8 +126,6 @@ func dispatch(pl *PairingLogic, cmd string, cmdArgs []string, userID string, use
 			break
 		}
 		rec.isSkippingTomorrow = false
-
-		ctx := context.Background()
 
 		err := pl.rdb.Set(ctx, userID, rec)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -1,18 +1,60 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+
+	"cloud.google.com/go/firestore"
 )
 
 // It's alive! The application starts here.
 func main() {
-	http.HandleFunc("/", nope)
-	http.HandleFunc("/webhooks", handle)
-	http.HandleFunc("/match", match)
-	http.HandleFunc("/endofbatch", endofbatch)
+
+	// setting up database connection: 2 clients encapsulated into PairingLogic struct
+	ctx := context.Background()
+
+	rc, err := firestore.NewClient(ctx, "pairing-bot-284823")
+	if err != nil {
+		log.Panic(err)
+	}
+	defer rc.Close()
+
+	// TODO context
+	ac, err := firestore.NewClient(ctx, "pairing-bot-284823")
+	if err != nil {
+		log.Panic(err)
+	}
+	defer ac.Close()
+
+	rdb := &FirestoreRecurserDB{
+		client: rc,
+	}
+
+	adb := &FirestoreAPIAuthDB{
+		client: ac,
+	}
+
+	ur := &zulipUserRequest{}
+
+	un := &zulipUserNotification{
+		botUsername: "pairing-bot@recurse.zulipchat.com",
+		zulipAPIURL: "https://recurse.zulipchat.com/api/v1/messages",
+	}
+
+	pl := &PairingLogic{
+		rdb: rdb,
+		adb: adb,
+		ur:  ur,
+		un:  un,
+	}
+
+	http.HandleFunc("/", nope)                    // will this handle anything that's not defined?
+	http.HandleFunc("/webhooks", pl.handle)       // from zulip
+	http.HandleFunc("/match", pl.match)           // from GCP
+	http.HandleFunc("/endofbatch", pl.endofbatch) // manually triggered
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/main.go
+++ b/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+// It's alive! The application starts here.
+func main() {
+	http.HandleFunc("/", nope)
+	http.HandleFunc("/webhooks", handle)
+	http.HandleFunc("/match", match)
+	http.HandleFunc("/endofbatch", endofbatch)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("Defaulting to port %s", port)
+	}
+
+	if m, ok := os.LookupEnv("PB_MAINT"); ok {
+		if m == "true" {
+			maintenanceMode = true
+		}
+	}
+
+	log.Printf("Listening on port %s", port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 func main() {
 
 	// setting up database connection: 2 clients encapsulated into PairingLogic struct
+
 	ctx := context.Background()
 
 	rc, err := firestore.NewClient(ctx, "pairing-bot-284823")
@@ -22,7 +23,6 @@ func main() {
 	}
 	defer rc.Close()
 
-	// TODO context
 	ac, err := firestore.NewClient(ctx, "pairing-bot-284823")
 	if err != nil {
 		log.Panic(err)

--- a/pairing-bot.go
+++ b/pairing-bot.go
@@ -33,32 +33,6 @@ const zulipAPIURL = "https://recurse.zulipchat.com/api/v1/messages"
 
 var maintenanceMode = false
 
-// This is a struct that gets only what
-// we need from the incoming JSON payload
-type incomingJSON struct {
-	Data    string `json:"data"`
-	Token   string `json:"token"`
-	Trigger string `json:"trigger"`
-	Message struct {
-		SenderID         int         `json:"sender_id"`
-		DisplayRecipient interface{} `json:"display_recipient"`
-		SenderEmail      string      `json:"sender_email"`
-		SenderFullName   string      `json:"sender_full_name"`
-	} `json:"message"`
-}
-
-// Zulip has to get JSON back from the bot,
-// this does that. An empty message field stops
-// zulip from throwing an error at the user that
-// messaged the bot, but doesn't send a response
-type botResponse struct {
-	Message string `json:"content"`
-}
-
-type botNoResponse struct {
-	Message bool `json:"response_not_required"`
-}
-
 func sanityCheck(ctx context.Context, client *firestore.Client, w http.ResponseWriter, r *http.Request) (incomingJSON, error) {
 	var userReq incomingJSON
 	// Look at the incoming webhook and slurp up the JSON

--- a/pairing-bot.go
+++ b/pairing-bot.go
@@ -3,79 +3,76 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
-	"net/url"
-	"strconv"
-	"strings"
 	"time"
-
-	"cloud.google.com/go/firestore"
-	"google.golang.org/api/iterator"
 )
 
 const owner string = `@_**Maren Beam (SP2'19)**`
-
-// this is the "id" field from zulip, and is a permanent user ID that's not secret
-// Pairing Bot's owner can add their ID here for testing. ctrl+f "ownerID" to see where it's used
-const ownerID = 215391
-
 const oddOneOutMessage string = "OK this is awkward.\nThere were an odd number of people in the match-set today, which means that one person couldn't get paired. Unfortunately, it was you -- I'm really sorry :(\nI promise it's not personal, it was very much random. Hopefully this doesn't happen again too soon. Enjoy your day! <3"
 const matchedMessage = "Hi you two! You've been matched for pairing :)\n\nHave fun!"
 const offboardedMessage = "Hi! You've been unsubscribed from Pairing Bot.\n\nThis happens at the end of every batch, when everyone is offboarded even if they're still in batch. If you'd like to re-subscribe, just send me a message that says `subscribe`.\n\nBe well! :)"
 
-const botEmailAddress = "pairing-bot@recurse.zulipchat.com"
-const zulipAPIURL = "https://recurse.zulipchat.com/api/v1/messages"
-
 var maintenanceMode = false
 
-func sanityCheck(ctx context.Context, client *firestore.Client, w http.ResponseWriter, r *http.Request) (incomingJSON, error) {
-	var userReq incomingJSON
-	// Look at the incoming webhook and slurp up the JSON
-	// Error if the JSON from Zulip istelf is bad
-	err := json.NewDecoder(r.Body).Decode(&userReq)
-	if err != nil {
-		http.NotFound(w, r)
-		return userReq, err
-	}
+// this is the "id" field from zulip, and is a permanent user ID that's not secret
+// Pairing Bot's owner can add their ID here for testing. ctrl+f "ownerID" to see where it's used
+const ownerID = "215391"
 
-	// validate our zulip-bot token
-	// this was manually put into the database before deployment
-	doc, err := client.Collection("botauth").Doc("token").Get(ctx)
-	if err != nil {
-		log.Println("Something weird happened trying to read the auth token from the database")
-		return userReq, err
-	}
-	token := doc.Data()
-	if userReq.Token != token["value"] {
-		http.NotFound(w, r)
-		return userReq, errors.New("unauthorized interaction attempt")
-	}
-	return userReq, err
+type PairingLogic struct {
+	rdb RecurserDB
+	adb APIAuthDB
+	ur  userRequest
+	un  userNotification
 }
 
-func handle(w http.ResponseWriter, r *http.Request) {
+func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	responder := json.NewEncoder(w)
+
+	// check and authorize the incoming request
+	// observation: we only validate requests for /webhooks, i.e. user input through zulip
+
 	ctx := context.Background()
-	client, err := firestore.NewClient(ctx, "pairing-bot-284823")
+	err := pl.ur.validateJSON(ctx, r)
 	if err != nil {
-		log.Panic(err)
+		http.NotFound(w, r)
 	}
-	// sanity check the incoming request
-	userReq, err := sanityCheck(ctx, client, w, r)
+
+	botAuth, err := pl.adb.GetKey(ctx, "botauth", "token")
 	if err != nil {
-		log.Println(err)
+		log.Println("Something weird happened trying to read the auth token from the database")
+	}
+
+	if !pl.ur.validateAuthCreds(ctx, botAuth) {
+		http.NotFound(w, r)
+	}
+
+	intro := pl.ur.validateInteractionType(ctx)
+	if intro != nil {
+		err = responder.Encode(intro)
+		if err != nil {
+			log.Println(err)
+		}
 		return
 	}
+
+	ignore := pl.ur.ignoreInteractionType(ctx)
+	if ignore != nil {
+		err = responder.Encode(ignore)
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
+	userData := pl.ur.extractUserData(ctx)
 
 	// for testing only
 	// this responds with a maintenance message and quits if the request is coming from anyone other than the owner
 	if maintenanceMode {
-		if userReq.Message.SenderID != ownerID {
+		if userData.userID != ownerID {
 			err = responder.Encode(botResponse{`pairing bot is down for maintenance`})
 			if err != nil {
 				log.Println(err)
@@ -84,34 +81,20 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if userReq.Trigger != "private_message" {
-		err = responder.Encode(botResponse{"Hi! I'm Pairing Bot (she/her)!\n\nSend me a PM that says `subscribe` to get started :smiley:\n\n:pear::robot:\n:octopus::octopus:"})
-		if err != nil {
-			log.Println(err)
-		}
-		return
-	}
-	// if there aren't two 'recipients' (one sender and one receiver),
-	// then don't respond. this stops pairing bot from responding in the group
-	// chat she starts when she matches people
-	if len(userReq.Message.DisplayRecipient.([]interface{})) != 2 {
-		err = responder.Encode(botNoResponse{true})
-		if err != nil {
-			log.Println(err)
-		}
-		return
-	}
-	// you *should* be able to throw any freakin string at this thing and get back a valid command for dispatch()
+	// you *should* be able to throw any string at this thing and get back a valid command for dispatch()
 	// if there are no commad arguments, cmdArgs will be nil
-	cmd, cmdArgs, err := parseCmd(userReq.Data)
+	cmd, cmdArgs, err := pl.ur.sanitizeUserInput(ctx)
 	if err != nil {
 		log.Println(err)
 	}
+
 	// the tofu and potatoes right here y'all
-	response, err := dispatch(ctx, client, cmd, cmdArgs, strconv.Itoa(userReq.Message.SenderID), userReq.Message.SenderEmail, userReq.Message.SenderFullName)
+
+	response, err := dispatch(pl, cmd, cmdArgs, userData.userID, userData.userEmail, userData.userName)
 	if err != nil {
 		log.Println(err)
 	}
+
 	err = responder.Encode(botResponse{response})
 	if err != nil {
 		log.Println(err)
@@ -124,7 +107,7 @@ func nope(w http.ResponseWriter, r *http.Request) {
 
 // "match" makes matches for pairing, and messages those people to notify them of their match
 // it runs once per day at 8am (it's triggered with app engine's cron service)
-func match(w http.ResponseWriter, r *http.Request) {
+func (pl *PairingLogic) match(w http.ResponseWriter, r *http.Request) {
 	// Check that the request is originating from within app engine
 	// https://cloud.google.com/appengine/docs/flexible/go/scheduling-jobs-with-cron-yaml#validating_cron_requests
 	if r.Header.Get("X-Appengine-Cron") != "true" {
@@ -132,53 +115,29 @@ func match(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// setting up database connection
 	ctx := context.Background()
-	client, err := firestore.NewClient(ctx, "pairing-bot-284823")
-	if err != nil {
-		log.Panic(err)
-	}
-	var recursersList []map[string]interface{}
-	var skippersList []map[string]interface{}
-	// this gets the time from system time, which is UTC
-	// on app engine (and most other places). This works
-	// fine for us in NYC, but might not if pairing bot
-	// were ever running in another time zone
-	today := strings.ToLower(time.Now().Weekday().String())
 
-	// ok this is how we have to get all the recursers. it's weird.
-	// this query returns an iterator, and then we have to use firestore
-	// magic to iterate across the results of the query and store them
-	// into our 'recursersList' variable which is a slice of map[string]interface{}
-	iter := client.Collection("recursers").Where("isSkippingTomorrow", "==", false).Where("schedule."+today, "==", true).Documents(ctx)
-	for {
-		doc, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			log.Panic(err)
-		}
-		recursersList = append(recursersList, doc.Data())
+	recursersList, err := pl.rdb.ListPairingTomorrow(ctx)
+	if err != nil {
+		log.Printf("Could not get list of recursers from DB: %s\n", err)
+	}
+	// TODO do we want to return in case of errors here?
+
+	ctx = context.Background()
+
+	skippersList, err := pl.rdb.ListSkippingTomorrow(ctx)
+	if err != nil {
+		log.Printf("Could not get list of skippers from DB: %s\n", err)
 	}
 
 	// get everyone who was set to skip today and set them back to isSkippingTomorrow = false
-	iter = client.Collection("recursers").Where("isSkippingTomorrow", "==", true).Documents(ctx)
-	for {
-		doc, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
+
+	ctx = context.Background()
+
+	for _, skipper := range skippersList {
+		err := pl.rdb.UnsetSkippingTomorrow(ctx, skipper)
 		if err != nil {
-			log.Panic(err)
-		}
-		skippersList = append(skippersList, doc.Data())
-	}
-	for i := range skippersList {
-		skippersList[i]["isSkippingTomorrow"] = false
-		_, err = client.Collection("recursers").Doc(skippersList[i]["id"].(string)).Set(ctx, skippersList[i], firestore.MergeAll)
-		if err != nil {
-			log.Println(err)
+			log.Printf("Could not unset skipping for recurser %v: %s\n", skipper.id, err)
 		}
 	}
 
@@ -192,14 +151,10 @@ func match(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// message the peeps!
-	doc, err := client.Collection("apiauth").Doc("key").Get(ctx)
+	botPassword, err := pl.adb.GetKey(ctx, "apiauth", "key")
 	if err != nil {
-		log.Panic(err)
+		log.Println("Something weird happened trying to read the auth token from the database")
 	}
-	apikey := doc.Data()
-	botUsername := botEmailAddress
-	botPassword := apikey["value"].(string)
-	zulipClient := &http.Client{}
 
 	// if there's an odd number today, message the last person in the list
 	// and tell them they don't get a match today, then knock them off the list
@@ -207,54 +162,26 @@ func match(w http.ResponseWriter, r *http.Request) {
 		recurser := recursersList[len(recursersList)-1]
 		recursersList = recursersList[:len(recursersList)-1]
 		log.Println("Someone was the odd-one-out today")
-		messageRequest := url.Values{}
-		messageRequest.Add("type", "private")
-		messageRequest.Add("to", recurser["email"].(string))
-		messageRequest.Add("content", oddOneOutMessage)
-		req, err := http.NewRequest("POST", zulipAPIURL, strings.NewReader(messageRequest.Encode()))
+
+		err := pl.un.sendUserMessage(ctx, botPassword, recurser.email, oddOneOutMessage)
 		if err != nil {
-			log.Println(err)
+			log.Printf("Error when trying to send oddOneOut message to %s: %s\n", recurser.email, err)
 		}
-		req.SetBasicAuth(botUsername, botPassword)
-		req.Header.Set("content-type", "application/x-www-form-urlencoded")
-		resp, err := zulipClient.Do(req)
-		if err != nil {
-			log.Panic(err)
-		}
-		defer resp.Body.Close()
-		respBodyText, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Println(err)
-		}
-		log.Println(string(respBodyText))
+
 	}
 
 	for i := 0; i < len(recursersList); i += 2 {
-		messageRequest := url.Values{}
-		messageRequest.Add("type", "private")
-		messageRequest.Add("to", recursersList[i]["email"].(string)+", "+recursersList[i+1]["email"].(string))
-		messageRequest.Add("content", matchedMessage)
-		req, err := http.NewRequest("POST", zulipAPIURL, strings.NewReader(messageRequest.Encode()))
+
+		emails := recursersList[i].email + ", " + recursersList[i+1].email
+		err := pl.un.sendUserMessage(ctx, botPassword, emails, matchedMessage)
 		if err != nil {
-			log.Println(err)
+			log.Printf("Error when trying to send matchedMessage to %s: %s\n", emails, err)
 		}
-		req.SetBasicAuth(botUsername, botPassword)
-		req.Header.Set("content-type", "application/x-www-form-urlencoded")
-		resp, err := zulipClient.Do(req)
-		if err != nil {
-			log.Panic(err)
-		}
-		defer resp.Body.Close()
-		respBodyText, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Println(err)
-		}
-		log.Println(string(respBodyText))
-		log.Println(recursersList[i]["email"].(string), "was", "matched", "with", recursersList[i+1]["email"].(string))
+		log.Println(recursersList[i].email, "was", "matched", "with", recursersList[i+1].email)
 	}
 }
 
-func endofbatch(w http.ResponseWriter, r *http.Request) {
+func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 	// Check that the request is originating from within app engine
 	// https://cloud.google.com/appengine/docs/flexible/go/scheduling-jobs-with-cron-yaml#validating_cron_requests
 	if r.Header.Get("X-Appengine-Cron") != "true" {
@@ -262,44 +189,30 @@ func endofbatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// setting up database connection
+	// getting all the recursers
 	ctx := context.Background()
-	client, err := firestore.NewClient(ctx, "pairing-bot-284823")
+	recursersList, err := pl.rdb.GetAllUsers(ctx)
 	if err != nil {
 		log.Panic(err)
-	}
-	var recursersList []map[string]interface{}
-
-	// getting all the recursers
-	iter := client.Collection("recursers").Documents(ctx)
-	for {
-		doc, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			log.Panic(err)
-		}
-		recursersList = append(recursersList, doc.Data())
 	}
 
 	// message and offboard everyone (delete them from the database)
-	doc, err := client.Collection("apiauth").Doc("key").Get(ctx)
+
+	ctx = context.Background()
+	botPassword, err := pl.adb.GetKey(ctx, "apiauth", "key")
 	if err != nil {
-		log.Panic(err)
+		log.Println("Something weird happened trying to read the auth token from the database")
 	}
-	apikey := doc.Data()
-	botUsername := botEmailAddress
-	botPassword := apikey["value"].(string)
-	zulipClient := &http.Client{}
+
+	ctx = context.Background() // TODO my use of contexts is definitely wrong
 
 	for i := 0; i < len(recursersList); i++ {
-		recurserID := recursersList[i]["id"].(string)
-		recurserEmail := recursersList[i]["email"].(string)
-		messageRequest := url.Values{}
+
+		recurserID := recursersList[i].id
+		recurserEmail := recursersList[i].email
 		var message string
 
-		_, err = client.Collection("recursers").Doc(recurserID).Delete(ctx)
+		err = pl.rdb.Delete(ctx, recurserID)
 		if err != nil {
 			log.Println(err)
 			message = fmt.Sprintf("Uh oh, I was trying to offboard you since it's the end of batch, but something went wrong. Consider messaging %v to let them know this happened.", owner)
@@ -308,34 +221,17 @@ func endofbatch(w http.ResponseWriter, r *http.Request) {
 			message = offboardedMessage
 		}
 
-		messageRequest.Add("type", "private")
-		messageRequest.Add("to", recurserEmail)
-		messageRequest.Add("content", message)
-		req, err := http.NewRequest("POST", zulipAPIURL, strings.NewReader(messageRequest.Encode()))
+		err := pl.un.sendUserMessage(ctx, botPassword, recurserEmail, message)
 		if err != nil {
-			log.Println(err)
+			log.Printf("Error when trying to send offboarding message to %s: %s\n", recurserEmail, err)
 		}
-		req.SetBasicAuth(botUsername, botPassword)
-		req.Header.Set("content-type", "application/x-www-form-urlencoded")
-		resp, err := zulipClient.Do(req)
-		if err != nil {
-			log.Panic(err)
-		}
-		defer resp.Body.Close()
-		respBodyText, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Println(err)
-		}
-		log.Println(string(respBodyText))
 	}
 }
 
 // this shuffles our recursers.
-// TODO: source of randomness is time, but this runs at the
-// same time each day. Is that ok?
-func shuffle(slice []map[string]interface{}) []map[string]interface{} {
+func shuffle(slice []Recurser) []Recurser {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	ret := make([]map[string]interface{}, len(slice))
+	ret := make([]Recurser, len(slice))
 	perm := r.Perm(len(slice))
 	for i, randIndex := range perm {
 		ret[i] = slice[randIndex]

--- a/pairing-bot.go
+++ b/pairing-bot.go
@@ -10,15 +10,12 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
 
 	"cloud.google.com/go/firestore"
 	"google.golang.org/api/iterator"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const owner string = `@_**Maren Beam (SP2'19)**`
@@ -27,19 +24,12 @@ const owner string = `@_**Maren Beam (SP2'19)**`
 // Pairing Bot's owner can add their ID here for testing. ctrl+f "ownerID" to see where it's used
 const ownerID = 215391
 
-const helpMessage string = "**How to use Pairing Bot:**\n* `subscribe` to start getting matched with other Pairing Bot users for pair programming\n* `schedule monday wednesday friday` to set your weekly pairing schedule\n  * In this example, I've been set to find pairing partners for you on every Monday, Wednesday, and Friday\n  * You can schedule pairing for any combination of days in the week\n* `skip tomorrow` to skip pairing tomorrow\n  * This is valid until matches go out at 04:00 UTC\n* `unskip tomorrow` to undo skipping tomorrow\n* `status` to show your current schedule, skip status, and name\n* `unsubscribe` to stop getting matched entirely\n\nIf you've found a bug, please [submit an issue on github](https://github.com/thwidge/pairing-bot/issues)!"
-const subscribeMessage string = "Yay! You're now subscribed to Pairing Bot!\nCurrently, I'm set to find pair programming partners for you on **Mondays**, **Tuesdays**, **Wednesdays**, **Thursdays**, and **Fridays**.\nYou can customize your schedule any time with `schedule` :)"
-const unsubscribeMessage string = "You're unsubscribed!\nI won't find pairing partners for you unless you `subscribe`.\n\nBe well :)"
-const notSubscribedMessage string = "You're not subscribed to Pairing Bot <3"
 const oddOneOutMessage string = "OK this is awkward.\nThere were an odd number of people in the match-set today, which means that one person couldn't get paired. Unfortunately, it was you -- I'm really sorry :(\nI promise it's not personal, it was very much random. Hopefully this doesn't happen again too soon. Enjoy your day! <3"
 const matchedMessage = "Hi you two! You've been matched for pairing :)\n\nHave fun!"
 const offboardedMessage = "Hi! You've been unsubscribed from Pairing Bot.\n\nThis happens at the end of every batch, when everyone is offboarded even if they're still in batch. If you'd like to re-subscribe, just send me a message that says `subscribe`.\n\nBe well! :)"
 
 const botEmailAddress = "pairing-bot@recurse.zulipchat.com"
 const zulipAPIURL = "https://recurse.zulipchat.com/api/v1/messages"
-
-var writeErrorMessage = fmt.Sprintf("Something went sideways while writing to the database. You should probably ping %v", owner)
-var readErrorMessage = fmt.Sprintf("Something went sideways while reading from the database. You should probably ping %v", owner)
 
 var maintenanceMode = false
 
@@ -92,204 +82,6 @@ func sanityCheck(ctx context.Context, client *firestore.Client, w http.ResponseW
 		return userReq, errors.New("unauthorized interaction attempt")
 	}
 	return userReq, err
-}
-
-func dispatch(ctx context.Context, client *firestore.Client, cmd string, cmdArgs []string, userID string, userEmail string, userName string) (string, error) {
-	var response string
-	var err error
-	var recurser = map[string]interface{}{
-		"id":                 "string",
-		"name":               "string",
-		"email":              "string",
-		"isSkippingTomorrow": false,
-		"schedule": map[string]interface{}{
-			"monday":    false,
-			"tuesday":   false,
-			"wednesday": false,
-			"thursday":  false,
-			"friday":    false,
-			"saturday":  false,
-			"sunday":    false,
-		},
-	}
-
-	// get the users "document" (database entry) out of firestore
-	// we temporarily keep it in 'doc'
-	doc, err := client.Collection("recursers").Doc(userID).Get(ctx)
-	// this says "if there's an error, and if that error was not document-not-found"
-	if err != nil && status.Code(err) != codes.NotFound {
-		response = readErrorMessage
-		return response, err
-	}
-	// if there's a db entry, that means they were already subscribed to pairing bot
-	// if there's not, they were not subscribed
-	isSubscribed := doc.Exists()
-
-	// if the user is in the database, get their current state into this map
-	// also assign their zulip name to the name field, just in case it changed
-	// also assign their email, for the same reason
-	if isSubscribed {
-		recurser = doc.Data()
-		recurser["name"] = userName
-		recurser["email"] = userEmail
-	}
-	// here's the actual actions. command input from
-	// the user has already been sanitized, so we can
-	// trust that cmd and cmdArgs only have valid stuff in them
-	switch cmd {
-	case "schedule":
-		if !isSubscribed {
-			response = notSubscribedMessage
-			break
-		}
-		// create a new blank schedule
-		var newSchedule = map[string]interface{}{
-			"monday":    false,
-			"tuesday":   false,
-			"wednesday": false,
-			"thursday":  false,
-			"friday":    false,
-			"saturday":  false,
-			"sunday":    false,
-		}
-		// populate it with the new days they want to pair on
-		for _, day := range cmdArgs {
-			newSchedule[day] = true
-		}
-		// put it in the database
-		recurser["schedule"] = newSchedule
-		_, err = client.Collection("recursers").Doc(userID).Set(ctx, recurser, firestore.MergeAll)
-		if err != nil {
-			response = writeErrorMessage
-			break
-		}
-		response = "Awesome, your new schedule's been set! You can check it with `status`."
-
-	case "subscribe":
-		if isSubscribed {
-			response = "You're already subscribed! Use `schedule` to set your schedule."
-			break
-		}
-
-		// recurser isn't really a type, because we're using maps
-		// and not struct. but we're using it *as* a type,
-		// and this is the closest thing to a definition that occurs
-		recurser = map[string]interface{}{
-			"id":                 userID,
-			"name":               userName,
-			"email":              userEmail,
-			"isSkippingTomorrow": false,
-			"schedule": map[string]interface{}{
-				"monday":    true,
-				"tuesday":   true,
-				"wednesday": true,
-				"thursday":  true,
-				"friday":    true,
-				"saturday":  false,
-				"sunday":    false,
-			},
-		}
-		_, err = client.Collection("recursers").Doc(userID).Set(ctx, recurser)
-		if err != nil {
-			response = writeErrorMessage
-			break
-		}
-		response = subscribeMessage
-
-	case "unsubscribe":
-		if !isSubscribed {
-			response = notSubscribedMessage
-			break
-		}
-		_, err = client.Collection("recursers").Doc(userID).Delete(ctx)
-		if err != nil {
-			response = writeErrorMessage
-			break
-		}
-		response = unsubscribeMessage
-
-	case "skip":
-		if !isSubscribed {
-			response = notSubscribedMessage
-			break
-		}
-		recurser["isSkippingTomorrow"] = true
-		_, err = client.Collection("recursers").Doc(userID).Set(ctx, recurser, firestore.MergeAll)
-		if err != nil {
-			response = writeErrorMessage
-			break
-		}
-		response = `Tomorrow: cancelled. I feel you. **I will not match you** for pairing tomorrow <3`
-
-	case "unskip":
-		if !isSubscribed {
-			response = notSubscribedMessage
-			break
-		}
-		recurser["isSkippingTomorrow"] = false
-		_, err = client.Collection("recursers").Doc(userID).Set(ctx, recurser, firestore.MergeAll)
-		if err != nil {
-			response = writeErrorMessage
-			break
-		}
-		response = "Tomorrow: uncancelled! Heckin *yes*! **I will match you** for pairing tomorrow :)"
-
-	case "status":
-		if !isSubscribed {
-			response = notSubscribedMessage
-			break
-		}
-		// this particular days list is for sorting and printing the
-		// schedule correctly, since it's stored in a map in all lowercase
-		var daysList = []string{
-			"Monday",
-			"Tuesday",
-			"Wednesday",
-			"Thursday",
-			"Friday",
-			"Saturday",
-			"Sunday"}
-
-		// get their current name
-		whoami := recurser["name"]
-
-		// get skip status and prepare to write a sentence with it
-		var skipStr string
-		if recurser["isSkippingTomorrow"].(bool) {
-			skipStr = " "
-		} else {
-			skipStr = " not "
-		}
-
-		// make a sorted list of their schedule
-		var schedule []string
-		for _, day := range daysList {
-			// this line is a little wild, sorry. it looks so weird because we
-			// have to do type assertion on both interface types
-			if recurser["schedule"].(map[string]interface{})[strings.ToLower(day)].(bool) {
-				schedule = append(schedule, day)
-			}
-		}
-		// make a lil nice-lookin schedule string
-		var scheduleStr string
-		for i := range schedule[:len(schedule)-1] {
-			scheduleStr += schedule[i] + "s, "
-		}
-		if len(schedule) > 1 {
-			scheduleStr += "and " + schedule[len(schedule)-1] + "s"
-		} else if len(schedule) == 1 {
-			scheduleStr += schedule[0] + "s"
-		}
-
-		response = fmt.Sprintf("* You're %v\n* You're scheduled for pairing on **%v**\n* **You're%vset to skip** pairing tomorrow", whoami, scheduleStr, skipStr)
-
-	case "help":
-		response = helpMessage
-	default:
-		// this won't execute because all input has been sanitized
-		// by parseCmd() and all cases are handled explicitly above
-	}
-	return response, err
 }
 
 func handle(w http.ResponseWriter, r *http.Request) {
@@ -350,29 +142,6 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err)
 	}
-}
-
-// It's alive! The application starts here.
-func main() {
-	http.HandleFunc("/", nope)
-	http.HandleFunc("/webhooks", handle)
-	http.HandleFunc("/match", match)
-	http.HandleFunc("/endofbatch", endofbatch)
-
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-		log.Printf("Defaulting to port %s", port)
-	}
-
-	if m, ok := os.LookupEnv("PB_MAINT"); ok {
-		if m == "true" {
-			maintenanceMode = true
-		}
-	}
-
-	log.Printf("Listening on port %s", port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
 }
 
 func nope(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Interfaces will allow us to mock the DB and Zulip interaction, and have more unit tests.
This PR does the following:

* Split up code into several files
* Add interfaces ´RecurserDB´ for DB lookups of subscriber information, and ´APIAuthDB´ for DB lookups of API/authentication tokens. Move existing implementation of DB queries into ´FirestoreRecurserDB´ and ´FirestoreAPIAuthDB´ types implementing these interfaces.
* Add interfaces ´userRequest´ for handling user requests to the bot through the client (atm Zulip), and ´userNotification´ for sending notifications to users (e.g for matches and offboarding). Move existing implementation of client interaction into ´zulipUserRequest´ and ´zulipUserNotification´ types implementing these interfaces.
* Add ´PairingLogic´ type that holds the types for DB and client interaction.
* Make the HTTP handle functions methods with ´PairingLogic´ as the receiver.

To do:
* ´context´ was added, but not used in a meaningful way yet. It shouldn't do any harm but maybe some ´context.Background()´ can be cleaned up even before merging this.
* Error handling might not be super consistent yet (when to log? when to panic?), but can be addressed separately I guess.

This PR is pretty big and I'm not sure if it's reviewable or testable enough to be merged as is. Even if we don't end up merging it, it has been useful as a learning project and can maybe serve as a reference for future discussions.

Thanks @rickypai, @nyghtowl, @Mathew-Estafanous and @ameliariely for advice and pairing sessions on this! 