### PR TITLE
Fix issue when the map is converted to a recurser struct

### DIFF
--- a/database.go
+++ b/database.go
@@ -88,19 +88,35 @@ func (f *FirestoreRecurserDB) GetByUserID(ctx context.Context, userID, userEmail
 	// if there's not, they were not subscribed
 	isSubscribed := doc.Exists()
 
+	var r Recurser
 	// if the user is in the database, get their current state into this map
 	// also assign their zulip name to the name field, just in case it changed
 	// also assign their email, for the same reason
-	var recurser map[string]interface{}
-
 	if isSubscribed {
+		var recurser map[string]interface{}
 		recurser = doc.Data()
 		recurser["name"] = userName
 		recurser["email"] = userEmail
+		r = MapToStruct(recurser)
+	} else {
+		// User is not subscribed, so provide a default recurser struct instead.
+		r = Recurser{
+			id: userID,
+			name: userName,
+			email: userEmail,
+			isSkippingTomorrow: false,
+			schedule: map[string]interface{}{
+				"monday":    true,
+				"tuesday":   true,
+				"wednesday": true,
+				"thursday":  true,
+				"friday":    true,
+				"saturday":  false,
+				"sunday":    false,
+			},
+		}
 	}
-
 	// now put the data from the recurser map into a Recurser struct
-	r := MapToStruct(recurser)
 	r.isSubscribed = isSubscribed
 	return r, nil
 }

--- a/dispatch.go
+++ b/dispatch.go
@@ -66,24 +66,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 			break
 		}
 
-		defaultSchedule := map[string]interface{}{
-			"monday":    true,
-			"tuesday":   true,
-			"wednesday": true,
-			"thursday":  true,
-			"friday":    true,
-			"saturday":  false,
-			"sunday":    false,
-		}
-
-		newRecurser := Recurser{id: userID,
-			name:               userName,
-			email:              userEmail,
-			isSkippingTomorrow: false,
-			schedule:           defaultSchedule,
-		}
-
-		err = pl.rdb.Set(ctx, userID, newRecurser)
+		err = pl.rdb.Set(ctx, userID, rec)
 
 		if err != nil {
 			response = writeErrorMessage


### PR DESCRIPTION
Users are not guaranteed to be found in the firestore DB and as a result, there would be an empty map. Previously, the logic did not takes this into account and would try converting the empty map to a struct, ultimately panicking.

This PR will fix this by adding logic that creates a default Recruser struct in the case that no user was found in the DB.