### PR TITLE
Consistency in error handling

### DIFF
--- a/database.go
+++ b/database.go
@@ -262,7 +262,6 @@ type FirestoreAPIAuthDB struct {
 func (f *FirestoreAPIAuthDB) GetKey(ctx context.Context, col, doc string) (string, error) {
 	res, err := f.client.Collection(col).Doc(doc).Get(ctx)
 	if err != nil {
-		log.Println("Something weird happened trying to read the auth token from the database")
 		return "", err
 	}
 

--- a/database.go
+++ b/database.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"strings"
 	"time"
 

--- a/database.go
+++ b/database.go
@@ -214,10 +214,7 @@ func (f *FirestoreRecurserDB) UnsetSkippingTomorrow(ctx context.Context, recurse
 	r["isSkippingTomorrow"] = false
 
 	_, err := f.client.Collection("recursers").Doc(r["id"].(string)).Set(ctx, r, firestore.MergeAll)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // implements RecurserDB

--- a/dispatch.go
+++ b/dispatch.go
@@ -52,9 +52,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 		// put it in the database
 		rec.schedule = newSchedule
 
-		err = pl.rdb.Set(ctx, userID, rec)
-
-		if err != nil {
+		if err = pl.rdb.Set(ctx, userID, rec); err != nil {
 			response = writeErrorMessage
 			break
 		}
@@ -66,9 +64,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 			break
 		}
 
-		err = pl.rdb.Set(ctx, userID, rec)
-
-		if err != nil {
+		if err = pl.rdb.Set(ctx, userID, rec); err != nil {
 			response = writeErrorMessage
 			break
 		}
@@ -80,9 +76,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 			break
 		}
 
-		err := pl.rdb.Delete(ctx, userID)
-
-		if err != nil {
+		if err := pl.rdb.Delete(ctx, userID); err != nil {
 			response = writeErrorMessage
 			break
 		}
@@ -96,8 +90,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 
 		rec.isSkippingTomorrow = true
 
-		err := pl.rdb.Set(ctx, userID, rec)
-		if err != nil {
+		if err := pl.rdb.Set(ctx, userID, rec); err != nil {
 			response = writeErrorMessage
 			break
 		}
@@ -110,8 +103,7 @@ func dispatch(ctx context.Context, pl *PairingLogic, cmd string, cmdArgs []strin
 		}
 		rec.isSkippingTomorrow = false
 
-		err := pl.rdb.Set(ctx, userID, rec)
-		if err != nil {
+		if err := pl.rdb.Set(ctx, userID, rec); err != nil {
 			response = writeErrorMessage
 			break
 		}

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -36,8 +36,8 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	// observation: we only validate requests for /webhooks, i.e. user input through zulip
 
 	ctx := r.Context()
-	err := pl.ur.validateJSON(r)
-	if err != nil {
+	
+	if err := pl.ur.validateJSON(r); err != nil {
 		http.NotFound(w, r)
 	}
 
@@ -52,8 +52,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 
 	intro := pl.ur.validateInteractionType()
 	if intro != nil {
-		err = responder.Encode(intro)
-		if err != nil {
+		if err = responder.Encode(intro); err != nil {
 			log.Println(err)
 		}
 		return
@@ -61,8 +60,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 
 	ignore := pl.ur.ignoreInteractionType()
 	if ignore != nil {
-		err = responder.Encode(ignore)
-		if err != nil {
+		if err = responder.Encode(ignore); err != nil {
 			log.Println(err)
 		}
 		return
@@ -74,8 +72,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	// this responds with a maintenance message and quits if the request is coming from anyone other than the owner
 	if maintenanceMode {
 		if userData.userID != ownerID {
-			err = responder.Encode(botResponse{`pairing bot is down for maintenance`})
-			if err != nil {
+			if err = responder.Encode(botResponse{`pairing bot is down for maintenance`}); err != nil {
 				log.Println(err)
 			}
 			return
@@ -96,8 +93,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 	}
 
-	err = responder.Encode(botResponse{response})
-	if err != nil {
+	if err = responder.Encode(botResponse{response}); err != nil {
 		log.Println(err)
 	}
 }

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -36,7 +36,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 	// observation: we only validate requests for /webhooks, i.e. user input through zulip
 
 	ctx := r.Context()
-	
+
 	if err := pl.ur.validateJSON(r); err != nil {
 		http.NotFound(w, r)
 	}

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -185,7 +185,7 @@ func (pl *PairingLogic) endofbatch(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	recursersList, err := pl.rdb.GetAllUsers(ctx)
 	if err != nil {
-		log.Panic(err)
+		log.Printf("Could not get list of recursers from DB: %s\n", err)
 	}
 
 	// message and offboard everyone (delete them from the database)

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -30,6 +30,8 @@ type PairingLogic struct {
 var randSrc = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
+	var err error
+
 	responder := json.NewEncoder(w)
 
 	// check and authorize the incoming request
@@ -37,7 +39,7 @@ func (pl *PairingLogic) handle(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	if err := pl.ur.validateJSON(r); err != nil {
+	if err = pl.ur.validateJSON(r); err != nil {
 		http.NotFound(w, r)
 	}
 

--- a/parse_cmd.go
+++ b/parse_cmd.go
@@ -44,7 +44,7 @@ func parseCmd(cmdStr string) (string, []string, error) {
 
 	// Big validation logic -- hellooo darkness my old frieeend
 	switch {
-	// if there's nothing in the command string srray
+	// if there's nothing in the command string array
 	case len(cmd) == 0:
 		err = errors.New("the user-issued command was blank")
 		return "help", nil, err


### PR DESCRIPTION
#26 

- log instead of panicking (except for startup)
- log when handling an error, not when returning it
- make use of initialization statements in case of short asignment statements to `err`, like
```go
if err = pl.rdb.Set(ctx, userID, rec); err != nil {
...
}
```